### PR TITLE
ステップ1-5. gem 'devise'を使ったログイン機能の実装（その3）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'devise'
 gem 'bootstrap'
 gem "devise-bootstrap5"
+gem "devise-i18n"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       responders
       warden (~> 1.2.3)
     devise-bootstrap5 (0.1.3)
+    devise-i18n (1.12.0)
+      devise (>= 4.9.0)
     erubi (1.12.0)
     execjs (2.9.1)
     ffi (1.16.3)
@@ -261,6 +263,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   devise-bootstrap5
+  devise-i18n
   jbuilder (~> 2.7)
   letter_opener_web
   listen (~> 3.3)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,8 +7,12 @@ class Users::RegistrationsController < Devise::RegistrationsController #deviseã
   end
 
   def update_resource(resource, params)
-    params.except!(:current_password)
+    if params[:password].present? || params[:password_confirmation].present?
+      super
+    else
+      params.except!(:current_password)
       resource.update_without_password(params)
+    end
   end
 
 

--- a/app/views/dash_boards/index.html.erb
+++ b/app/views/dash_boards/index.html.erb
@@ -2,9 +2,9 @@
   <div class="row justify-content-center">
     <div class="col-md-6 text-center">
       <h1>Dash Boards</h1>
-      <h2>Hello, <%= current_user.name %>!</h2>
-      <a href="<%= edit_user_registration_path %>" class="btn btn-primary">編集</a><br>
-      <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-warning" %>
+      <h2><%= current_user.name %></h2>
+      <a href="<%= edit_user_registration_path %>" class="btn btn-primary"><%= t('devise.dash_boards.edit')%> </a><br>
+      <%= link_to t('devise.dash_boards.logout'), destroy_user_session_path, method: :delete, class: "btn btn-warning" %>
     </div>
   </div>
 </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="text-center">Resend confirmation instructions</h2>
+      <h2 class="text-center"><%= t('devise.shared.links.didn_t_receive_confirmation_instructions') %></h2>
 
       <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "form" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
@@ -11,8 +11,8 @@
           <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "form-control" %>
         </div>
 
-        <div class="text-center">
-          <%= f.submit "Resend confirmation instructions", class: "btn btn-primary" %>
+        <div class="text-center"><br />
+          <%= f.submit t('devise.confirmations.new.resend_confirmation_instructions'), class: "btn btn-primary" %>
         </div>
       <% end %>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= @resource.email %> <%= t('devise.mailer.confirmation_instructions.greeting') %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('devise.mailer.confirmation_instructions.instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('devise.mailer.confirmation_instructions.action') , confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> <%= t('devise.mailer.reset_password_instructions.greeting') %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('devise.mailer.reset_password_instructions.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_2') %></p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_3') %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,27 +1,27 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="text-center">Change your password</h2>
+      <h2 class="text-center"><%= t('devise.passwords.edit.change_my_password') %></h2>
 
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "form" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
         <%= f.hidden_field :reset_password_token %>
 
         <div class="form-group">
-          <%= f.label :password, "New password" %><br />
+          <%= f.label :password, t('devise.passwords.edit.new_password') %><br />
           <% if @minimum_password_length %>
-            <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+            <em>(<%= @minimum_password_length %> <%= t('devise.passwords.edit.password') %> )</em><br />
           <% end %>
           <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-control" %>
         </div>
 
         <div class="form-group">
-          <%= f.label :password_confirmation, "Confirm new password" %><br />
+          <%= f.label :password_confirmation, t('devise.passwords.edit.confirm_new_password') %><br />
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
         </div>
 
         <div class="text-center">
-          <%= f.submit "Change my password", class: "btn btn-primary" %>
+          <%= f.submit t('devise.passwords.edit.change_my_password'), class: "btn btn-primary" %>
         </div>
       <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="text-center">Forgot your password?</h2>
+      <h2 class="text-center"><%= t('devise.passwords.new.forgot_your_password') %></h2>
 
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "form" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
@@ -11,8 +11,8 @@
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
         </div>
 
-        <div class="text-center">
-          <%= f.submit "Send me reset password instructions", class: "btn btn-primary" %>
+        <div class="text-center"><br />
+          <%= f.submit t('devise.passwords.new.send_me_reset_password_instructions'), class: "btn btn-primary" %>
         </div>
       <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="text-center">Edit <%= resource_name.to_s.humanize %></h2>
+      <h2 class="text-center"><%= current_user.name %><%= t('devise.registrations.edit.title') %></h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "form" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
@@ -21,11 +21,11 @@
         <% end %>
 
         <div class="form-group">
-          <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+          <%= f.label :password %> <i><%= t('devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it') %></i><br />
           <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
           <% if @minimum_password_length %>
             <br />
-            <em><%= @minimum_password_length %> characters minimum</em>
+            <em><%= @minimum_password_length %> <%= t('devise.registrations.edit.password') %></em>
           <% end %>
         </div>
 
@@ -35,19 +35,19 @@
         </div>
 
         <div class="form-group">
-          <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+          <%= f.label :current_password %> <br /><i><%= t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %></i><br />
           <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
         </div>
 
         <div class="text-center">
-          <%= f.submit "Update", class: "btn btn-primary" %>
+          <%= f.submit t('devise.registrations.edit.update'),  class: "btn btn-primary" %>
         </div>
       <% end %>
 
-      <h3 class="text-center">Cancel my account</h3>
-      <div class="text-center">Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></div>
+      <h3 class="text-center"><%= t('devise.registrations.edit.cancel_my_account') %></h</h3>
+      <div class="text-center"><%= t('devise.registrations.edit.unhappy') %><%= button_to t('devise.registrations.edit.cancel_my_account'), registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></div>
 
-      <%= link_to "Back", :back, class: "btn btn-secondary" %>
+      <%= link_to t('devise.registrations.edit.back'), :back, class: "btn btn-secondary" %>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,36 +1,33 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="text-center">Sign up</h2>
+      <h2 class="text-center"><%= t('devise.registrations.new.sign_up') %></h2>
 
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "form" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="form-group">
-          <%= f.label :name %><br />
+          <%= label_tag t('devise.registrations.new.name') %><br />
           <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
         </div>
 
         <div class="form-group">
-          <%= f.label :email %><br />
+          <%= label_tag t('devise.registrations.new.email') %><br />
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
         </div>
 
         <div class="form-group">
-          <%= f.label :password %>
-          <% if @minimum_password_length %>
-            <em>(<%= @minimum_password_length %> characters minimum)</em>
-          <% end %><br />
+          <%= label_tag t('devise.registrations.new.password') %><br />
           <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
         </div>
 
         <div class="form-group">
-          <%= f.label :password_confirmation %><br />
+          <%= label_tag t('devise.registrations.new.password_confirmation') %><br />
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
         </div>
 
         <div class="text-center">
-          <%= f.submit "Sign up", class: "btn btn-primary" %>
+          <%= f.submit t('devise.registrations.new.sign_up'), class: "btn btn-primary" %>
         </div>
       <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,11 +1,12 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2 class="text-center">Log in</h2>
+      <h2 class="text-center"><%= t('devise.sessions.new.sign_in') %></h2>
+
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "form" }) do |f| %>
         <div class="form-group">
-          <%= f.label :email %><br />
+          <%= f.label :mail %><br />
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
         </div>
 
@@ -22,7 +23,7 @@
         <% end %>
 
         <div class="text-center">
-          <%= f.submit "Log in", class: "btn btn-primary" %>
+          <%= f.submit t('devise.sessions.new.sign_in'), class: "btn btn-primary" %>
         </div>
       <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t('devise.sessions.new.sign_in'), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to t('devise.registrations.new.sign_up'), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to t('devise.passwords.new.forgot_your_password'), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to t('devise.shared.links.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to t('devise.unlocks.new.unlock_instructions_not_received'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module BeforeIntern
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
-
+    config.i18n.default_locale = :ja
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,163 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        email: "Eメール"
+        mail: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認用）"
+        name: "名前"
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: 次回から自動的にログイン
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認メールアドレス
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    dash_boards:
+      edit: 編集
+      logout: ログアウト
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}instruction"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 新しいパスワードの確認
+        new_password: 新しいパスワード
+        password: 文字以上
+
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: (空欄のままなら変更しません)
+        title: "の編集"
+        unhappy: 気に入りません
+        update: 更新
+        password: 文字以上
+        we_need_your_current_password_to_confirm_your_changes: (変更を反映するには現在のパスワードを入力してください)
+        back: 戻る
+      new:
+        sign_up: アカウント登録
+        name: 名前
+        email: Eメール
+        password: パスワード（6文字以上）
+        password_confirmation: パスワード（確認用）
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+        Log in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        Log in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      blank: "を入力してください"
+      invalid: "%{attribute}が正しくありません。"
+      blank: "%{attribute}を入力してください。"
+      too_short: "%{attribute}は%{count}文字以上で入力してください。"
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,183 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後


### PR DESCRIPTION
Feat/devise_japaneseを作成

PR概要
下記、機能を日本語リソースにて作成しました。 お手数ですが、ご確認をお願いいたします。
・ログイン画面(/, users/sign_in)
・新規登録画面(/users/sign_up)
・パスワード再設定画面(password/new )
・認証メール再設定画面(confirmation/new )
・letter_opener_webでの受信確認（reset_password/resend_confirmation）
・password/edit画面
・users/dash_boards画面
・ユーザーの編集画面(users/edit)
実装画面スクショを添付したスプシのリンク
https://docs.google.com/spreadsheets/d/1N-urKBFvUn-AsrihpHWShVkBTbyS9hzUjZIj5vReO2o/edit#gid=925771306